### PR TITLE
feat: Make mods not have an ID

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
       "version": "0.0.1",
       "dependencies": {
         "cf-fingerprint": "https://github.com/arschedev/cf-fingerprint",
+        "cf-fingerprint": "https://github.com/iTrooz/cf-fingerprint/",
         "pino": "^9.7.0",
         "pino-pretty": "^13.0.0",
       },
@@ -730,6 +731,8 @@
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "mclib/cf-fingerprint": ["cf-fingerprint@github:iTrooz/cf-fingerprint/#4e5293d", {}, "iTrooz-cf-fingerprint-4e5293d"],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,6 @@
       "name": "mclib",
       "version": "0.0.1",
       "dependencies": {
-        "cf-fingerprint": "https://github.com/arschedev/cf-fingerprint",
         "cf-fingerprint": "https://github.com/iTrooz/cf-fingerprint/",
         "pino": "^9.7.0",
         "pino-pretty": "^13.0.0",
@@ -296,7 +295,7 @@
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
-    "cf-fingerprint": ["cf-fingerprint@github:arschedev/cf-fingerprint#3642948", {}, "arschedev-cf-fingerprint-3642948"],
+    "cf-fingerprint": ["cf-fingerprint@github:iTrooz/cf-fingerprint/#4e5293d", {}, "iTrooz-cf-fingerprint-4e5293d"],
 
     "chai": ["chai@4.5.0", "", { "dependencies": { "assertion-error": "^1.1.0", "check-error": "^1.0.3", "deep-eql": "^4.1.3", "get-func-name": "^2.0.2", "loupe": "^2.3.6", "pathval": "^1.1.1", "type-detect": "^4.1.0" } }, "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw=="],
 
@@ -731,8 +730,6 @@
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
-
-    "mclib/cf-fingerprint": ["cf-fingerprint@github:iTrooz/cf-fingerprint/#4e5293d", {}, "iTrooz-cf-fingerprint-4e5293d"],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
       "name": "cli",
       "version": "0.0.1",
       "dependencies": {
+        "@commander-js/extra-typings": "^14.0.0",
         "commander": "^10.0.0",
         "mclib": "workspace:*",
       },
@@ -17,6 +18,8 @@
       "version": "0.0.1",
       "dependencies": {
         "cf-fingerprint": "https://github.com/arschedev/cf-fingerprint",
+        "pino": "^9.7.0",
+        "pino-pretty": "^13.0.0",
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -57,6 +60,8 @@
   },
   "packages": {
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
+
+    "@commander-js/extra-typings": ["@commander-js/extra-typings@14.0.0", "", { "peerDependencies": { "commander": "~14.0.0" } }, "sha512-hIn0ncNaJRLkZrxBIp5AsW/eXEHNKYQBh0aPdoUqNgD+Io3NIykQqpKFyKcuasZhicGaEZJX/JBSIkZ4e5x8Dg=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-W8bFfPA8DowP8l//sxjJLSLkD8iEjMc7cBVyP+u4cEv9sM7mdUCkgsj+t0n/BWPFtv7WWCN5Yzj0N6FJNUUqBQ=="],
 
@@ -274,6 +279,8 @@
 
     "assertion-error": ["assertion-error@1.1.0", "", {}, "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="],
 
+    "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
@@ -304,6 +311,8 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
+    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
+
     "commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
 
     "comment-json": ["comment-json@4.2.5", "", { "dependencies": { "array-timsort": "^1.0.3", "core-util-is": "^1.0.3", "esprima": "^4.0.1", "has-own-prop": "^2.0.0", "repeat-string": "^1.6.1" } }, "sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw=="],
@@ -322,6 +331,8 @@
 
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
+    "dateformat": ["dateformat@4.6.3", "", {}, "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="],
+
     "debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
     "dedent": ["dedent@1.5.1", "", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg=="],
@@ -335,6 +346,8 @@
     "devalue": ["devalue@5.1.1", "", {}, "sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw=="],
 
     "diff-sequences": ["diff-sequences@29.6.3", "", {}, "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "esbuild": ["esbuild@0.25.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.3", "@esbuild/android-arm": "0.25.3", "@esbuild/android-arm64": "0.25.3", "@esbuild/android-x64": "0.25.3", "@esbuild/darwin-arm64": "0.25.3", "@esbuild/darwin-x64": "0.25.3", "@esbuild/freebsd-arm64": "0.25.3", "@esbuild/freebsd-x64": "0.25.3", "@esbuild/linux-arm": "0.25.3", "@esbuild/linux-arm64": "0.25.3", "@esbuild/linux-ia32": "0.25.3", "@esbuild/linux-loong64": "0.25.3", "@esbuild/linux-mips64el": "0.25.3", "@esbuild/linux-ppc64": "0.25.3", "@esbuild/linux-riscv64": "0.25.3", "@esbuild/linux-s390x": "0.25.3", "@esbuild/linux-x64": "0.25.3", "@esbuild/netbsd-arm64": "0.25.3", "@esbuild/netbsd-x64": "0.25.3", "@esbuild/openbsd-arm64": "0.25.3", "@esbuild/openbsd-x64": "0.25.3", "@esbuild/sunos-x64": "0.25.3", "@esbuild/win32-arm64": "0.25.3", "@esbuild/win32-ia32": "0.25.3", "@esbuild/win32-x64": "0.25.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-qKA6Pvai73+M2FtftpNKRxJ78GIjmFXFxd/1DVBqGo/qNhLSfv+G12n9pNoWdytJC8U00TrViOwpjT0zgqQS8Q=="],
 
@@ -370,6 +383,8 @@
 
     "execa": ["execa@8.0.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^8.0.1", "human-signals": "^5.0.0", "is-stream": "^3.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^5.1.0", "onetime": "^6.0.0", "signal-exit": "^4.1.0", "strip-final-newline": "^3.0.0" } }, "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg=="],
 
+    "fast-copy": ["fast-copy@3.0.2", "", {}, "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
@@ -377,6 +392,10 @@
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fast-redact": ["fast-redact@3.5.0", "", {}, "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A=="],
+
+    "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
 
     "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
 
@@ -408,6 +427,8 @@
 
     "has-own-prop": ["has-own-prop@2.0.0", "", {}, "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ=="],
 
+    "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
+
     "human-id": ["human-id@4.1.1", "", { "bin": { "human-id": "dist/cli.js" } }, "sha512-3gKm/gCSUipeLsRYZbbdA1BD83lBoWUkZ7G9VFrhWPAU76KwYo5KR8V28bpoPm/ygy0x5/GCbpRQdY7VLYCoIg=="],
 
     "human-signals": ["human-signals@5.0.0", "", {}, "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ=="],
@@ -431,6 +452,8 @@
     "is-stream": ["is-stream@3.0.0", "", {}, "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
 
     "js-sha256": ["js-sha256@0.11.0", "", {}, "sha512-6xNlKayMZvds9h1Y1VWc0fQHQ82BxTXizWPEtEeGvmOUYpBRy4gbWroHLpzowe6xiQhHpelCQiE7HEdznyBL9Q=="],
 
@@ -482,6 +505,8 @@
 
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
     "mlly": ["mlly@1.7.4", "", { "dependencies": { "acorn": "^8.14.0", "pathe": "^2.0.1", "pkg-types": "^1.3.0", "ufo": "^1.5.4" } }, "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw=="],
 
     "modpackcreator": ["modpackcreator@workspace:web"],
@@ -497,6 +522,10 @@
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
     "npm-run-path": ["npm-run-path@5.3.0", "", { "dependencies": { "path-key": "^4.0.0" } }, "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ=="],
+
+    "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "onetime": ["onetime@6.0.0", "", { "dependencies": { "mimic-fn": "^4.0.0" } }, "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ=="],
 
@@ -520,6 +549,14 @@
 
     "picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
 
+    "pino": ["pino@9.7.0", "", { "dependencies": { "atomic-sleep": "^1.0.0", "fast-redact": "^3.1.1", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-vnMCM6xZTb1WDmLvtG2lE/2p+t9hDEIvTWJsu6FejkE62vB7gDhvzrpFR4Cw2to+9JNQxVnkAKVPA1KPB98vWg=="],
+
+    "pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
+
+    "pino-pretty": ["pino-pretty@13.0.0", "", { "dependencies": { "colorette": "^2.0.7", "dateformat": "^4.6.3", "fast-copy": "^3.0.2", "fast-safe-stringify": "^2.1.1", "help-me": "^5.0.0", "joycon": "^3.1.1", "minimist": "^1.2.6", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pump": "^3.0.0", "secure-json-parse": "^2.4.0", "sonic-boom": "^4.0.1", "strip-json-comments": "^3.1.1" }, "bin": { "pino-pretty": "bin.js" } }, "sha512-cQBBIVG3YajgoUjo1FdKVRX6t9XPxwB9lcNJVD5GCnNM4Y6T12YYx8c6zEejxQsU0wrg9TwmDulcE9LR7qcJqA=="],
+
+    "pino-std-serializers": ["pino-std-serializers@7.0.0", "", {}, "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA=="],
+
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
     "postcss": ["postcss@8.5.3", "", { "dependencies": { "nanoid": "^3.3.8", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A=="],
@@ -540,13 +577,21 @@
 
     "pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
 
+    "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
+
+    "pump": ["pump@3.0.3", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA=="],
+
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
+    "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
+
     "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
+    "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
     "repeat-string": ["repeat-string@1.6.1", "", {}, "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="],
 
@@ -559,6 +604,10 @@
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
+
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
+    "secure-json-parse": ["secure-json-parse@2.7.0", "", {}, "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="],
 
     "semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
 
@@ -574,7 +623,11 @@
 
     "sirv": ["sirv@3.0.1", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A=="],
 
+    "sonic-boom": ["sonic-boom@4.2.0", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "sqlite-wasm-kysely": ["sqlite-wasm-kysely@0.3.0", "", { "dependencies": { "@sqlite.org/sqlite-wasm": "^3.48.0-build2" }, "peerDependencies": { "kysely": "*" } }, "sha512-TzjBNv7KwRw6E3pdKdlRyZiTmUIE0UttT/Sl56MVwVARl/u5gp978KepazCJZewFUnlWHz9i3NQd4kOtP/Afdg=="],
 
@@ -595,6 +648,8 @@
     "svelte-check": ["svelte-check@4.1.7", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "chokidar": "^4.0.1", "fdir": "^6.2.0", "picocolors": "^1.0.0", "sade": "^1.7.4" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": ">=5.0.0" }, "bin": { "svelte-check": "bin/svelte-check" } }, "sha512-1jX4BzXrQJhC/Jt3SqYf6Ntu//vmfc6VWp07JkRfK2nn+22yIblspVUo96gzMkg0Zov8lQicxhxsMzOctwcMQQ=="],
 
     "svelte-eslint-parser": ["svelte-eslint-parser@1.1.3", "", { "dependencies": { "eslint-scope": "^8.2.0", "eslint-visitor-keys": "^4.0.0", "espree": "^10.0.0", "postcss": "^8.4.49", "postcss-scss": "^4.0.9", "postcss-selector-parser": "^7.0.0" }, "peerDependencies": { "svelte": "^3.37.0 || ^4.0.0 || ^5.0.0" }, "optionalPeers": ["svelte"] }, "sha512-DUc/z/vk+AFVoxGv54+BOBFqUrmUgNg2gSO2YqrE3OL6ro19/0azPmQj/4wN3s9RxuF5l7G0162q/Ddk4LJhZA=="],
+
+    "thread-stream": ["thread-stream@3.1.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A=="],
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
@@ -648,11 +703,15 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
     "yaml": ["yaml@1.10.2", "", {}, "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="],
 
     "yocto-queue": ["yocto-queue@1.2.1", "", {}, "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg=="],
 
     "zimmerframe": ["zimmerframe@1.1.2", "", {}, "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w=="],
+
+    "@commander-js/extra-typings/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,8 @@
         "@commander-js/extra-typings": "^14.0.0",
         "commander": "^10.0.0",
         "mclib": "workspace:*",
+        "pino": "^9.7.0",
+        "pino-pretty": "^13.0.0",
       },
     },
     "mclib": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "build": "(cd ../mclib && bun run build) && bun build src/index.ts --outdir dist --minify --target node",
-    "start": "(cd ../mclib && bun run build) && bun src/index.ts"
+    "start": "(cd ../mclib && bun run build) && bun src/index.ts",
+    "proxy-start": "HTTP_PROXY=http://127.0.0.1:8080 HTTPS_PROXY=http://127.0.0.1:8080 bun run start"
   }
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -4,7 +4,9 @@
   "dependencies": {
     "@commander-js/extra-typings": "^14.0.0",
     "commander": "^10.0.0",
-    "mclib": "workspace:*"
+    "mclib": "workspace:*",
+    "pino": "^9.7.0",
+    "pino-pretty": "^13.0.0"
   },
   "scripts": {
     "build": "(cd ../mclib && bun run build) && bun build src/index.ts --outdir dist --minify --target node",

--- a/cli/package.json
+++ b/cli/package.json
@@ -2,11 +2,12 @@
   "name": "cli",
   "version": "0.0.1",
   "dependencies": {
-    "mclib": "workspace:*",
-    "commander": "^10.0.0"
+    "@commander-js/extra-typings": "^14.0.0",
+    "commander": "^10.0.0",
+    "mclib": "workspace:*"
   },
   "scripts": {
     "build": "(cd ../mclib && bun run build) && bun build src/index.ts --outdir dist --minify --target node",
     "start": "(cd ../mclib && bun run build) && bun src/index.ts"
-  },
+  }
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,9 +1,30 @@
 #!/usr/bin/env bun
 
-import { Command } from 'commander';
-import { ModQueryService } from 'mclib';
+import { program } from '@commander-js/extra-typings';
+import { CurseForgeRepository, LocalSolutionFinder, LoggerConfig, ModLoader, ModQueryService, ModrinthRepository, LogLevel, Constraints } from 'mclib';
 
-const program = new Command();
+LoggerConfig.setLevel((process.env.LOG_LEVEL ?? "info") as LogLevel);
+
+function getModQueryService() {
+  const repositories = [
+    new ModrinthRepository(fetch),
+    new CurseForgeRepository(fetch),
+  ];
+  return new ModQueryService(repositories);
+}
+
+interface Options {
+  modId?: string[];
+  minVersion?: string;
+  maxVersion?: string;
+  loader?: string[];
+}
+
+function validate(modQueryService: ModQueryService, options: Options) {
+  if (!options.modId || options.modId.length === 0) {
+    throw new Error('At least one --mod-id is required.');
+  }
+}
 
 program
   .name('modpack-cli')
@@ -11,35 +32,34 @@ program
   .version('0.0.1');
 
 program
-  .command('create')
-  .description('Create a new modpack')
-  .option('--mod-name <modName...>', 'Mod IDs to include in the modpack')
-  .option('--min-version <version>', 'Minimum version of the modpack')
-  .option('--loader <loader...>', 'Loaders to support (e.g., forge, fabric)')
-  .action(async (options) => {
-    const { modName, minVersion, loader } = options;
+  .command('find-solutions').alias('fs')
+  .description('Find mod versions that match constraints')
+  .option('--mod-id <modID...>', 'Mod IDs to include in the modpack')
+  .option('--min-version <version>', 'Minimum Minecraft version to consider')
+  .option('--max-version <version>', 'Maximum Minecraft version to consider')
+  .option('--loader <loader...>', 'Loaders to consider (e.g., forge, fabric)', [])
+  .action(async (cliOptions: Options) => {
 
-    if (!modName || modName.length === 0) {
-      console.error('Error: At least one --mod-name is required.');
-      process.exit(1);
+    let modQueryService = getModQueryService();
+    validate(modQueryService, cliOptions);
+
+    console.log(`Searching for solutions..`);
+    let solutionFinder = new LocalSolutionFinder(modQueryService);
+    let solutions = await solutionFinder.findSolutions(cliOptions.modId!, {
+      minVersion: cliOptions.minVersion,
+      maxVersion: cliOptions.maxVersion,
+      loaders: cliOptions.loader as ModLoader[] | undefined,
+    });
+
+    if (solutions.length === 0) {
+      console.log('No solutions found.');
+      return;
     }
 
-    if (!minVersion) {
-      console.error('Error: --min-version is required.');
-      process.exit(1);
+    console.log(`Found ${solutions.length} solution(s):`);
+    for (const solution of solutions) {
+      console.log(`- Version: ${solution.mcConfig.mcVersion}, Loader: ${solution.mcConfig.loader}, Mods: ${solution.mods.length}/${cliOptions.modId?.length}`);
     }
-
-    if (!loader || loader.length === 0) {
-      console.error('Error: At least one --loader is required.');
-      process.exit(1);
-    }
-  });
-
-program
-  .command('list')
-  .description('List all modpacks')
-  .action(() => {
-    // TODO
   });
 
 program.parse(process.argv);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -126,8 +126,8 @@ program
     for (const solution of solutions) {
       logger.info(`- Version: ${solution.mcConfig.mcVersion}, Loader: ${solution.mcConfig.loader}, Mods: ${solution.mods.length}/${requestedModIds.length}`);
       if (cliOptions.details && solution.mods.length != requestedModIds.length) {
-        logger.info(`  Unsupported mods:`);
         let unsupportedMods = requestedModIds.filter(modId => !solution.mods.some(mod => mod.id === modId));
+        logger.info(`  Unsupported mods (${unsupportedMods.length}):`);
         for (const modId of unsupportedMods) {
           logger.info(`  - ${modId}`);
         }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -18,10 +18,21 @@ const logger = pino({
 });
 LoggerConfig.setLevel(LOG_LEVEL);
 
+async function timedFetch(input: RequestInfo | URL, options?: RequestInit): Promise<Response> {
+    const start = Date.now();
+    const response = await fetch(input, options);
+    const duration = Date.now() - start;
+    logger.debug(`fetch(${input}): ${duration}ms`);
+    if (!response.ok) {
+        logger.error(`Fetch failed for ${input}: ${response.status} ${response.statusText}`);
+    }
+    return response;
+}
+
 function getModQueryService() {
   const repositories = [
-    new ModrinthRepository(fetch),
-    new CurseForgeRepository(fetch),
+    new ModrinthRepository(timedFetch),
+    new CurseForgeRepository(timedFetch),
   ];
   return new ModQueryService(repositories);
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { program } from '@commander-js/extra-typings';
+import { program, Option } from '@commander-js/extra-typings';
 import { CurseForgeRepository, LocalSolutionFinder, LoggerConfig, ModLoader, ModQueryService, ModrinthRepository, LogLevel, Constraints, Solution, ModMetadata, RepositoryUtil, ModRepositoryName, ModRepoMetadata } from 'mclib';
 import { readFileSync } from 'fs';
 import pino from 'pino';
@@ -57,6 +57,7 @@ function getModQueryService(selectedRepos?: string[]) {
 interface CliOptions {
   modId?: string[];
   modFile?: string[];
+  exactVersion?: string;
   minVersion?: string;
   maxVersion?: string;
   loader?: string[];
@@ -182,6 +183,7 @@ program
   .description('Find mod versions that match constraints')
   .option('--mod-id <modID...>', 'Mod IDs to include in the modpack')
   .option('--mod-file <path...>', 'Mod IDs to include in the modpack')
+  .addOption(new Option('--exact-version <version>', 'Exact Minecraft version to consider').conflicts(['minVersion', 'maxVersion']))
   .option('--min-version <version>', 'Minimum Minecraft version to consider')
   .option('--max-version <version>', 'Maximum Minecraft version to consider')
   .option('--loader <loader...>', 'Loaders to consider (e.g., forge, fabric)', [])
@@ -204,8 +206,8 @@ program
       modQueryService,
       requestedMods,
       {
-        minVersion: cliOptions.minVersion,
-        maxVersion: cliOptions.maxVersion,
+        minVersion: cliOptions.exactVersion || cliOptions.minVersion,
+        maxVersion: cliOptions.exactVersion || cliOptions.maxVersion,
         loaders: new Set(cliOptions.loader as ModLoader[]),
       },
       cliOptions.nbSolutions,

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -114,13 +114,9 @@ async function findSolutions(
     logger.info('Sinytra mode: Injecting Forge and NeoForge into Fabric-compatible releases...');
     for (const mod of mods) {
       for (const release of mod.releases) {
-        if (release.loaders.includes(ModLoader.FABRIC)) {
-          if (!release.loaders.includes(ModLoader.FORGE)) {
-            release.loaders.push(ModLoader.FORGE);
-          }
-          if (!release.loaders.includes(ModLoader.NEOFORGE)) {
-            release.loaders.push(ModLoader.NEOFORGE);
-          }
+        if (release.loaders.has(ModLoader.FABRIC)) {
+          release.loaders.add(ModLoader.FORGE);
+          release.loaders.add(ModLoader.NEOFORGE);
           logger.trace(`Injected forge and neoforge into fabric-compatible release: ${mod.id} ${release.modVersion}`);
         }
       }
@@ -165,7 +161,7 @@ program
       {
         minVersion: cliOptions.minVersion,
         maxVersion: cliOptions.maxVersion,
-        loaders: cliOptions.loader as ModLoader[] | undefined,
+        loaders: new Set(cliOptions.loader as ModLoader[]),
       },
       cliOptions.nbSolutions,
       !!cliOptions.sinytra

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -37,7 +37,7 @@ function getModQueryService() {
   return new ModQueryService(repositories);
 }
 
-interface Options {
+interface CliOptions {
   modId?: string[];
   modFile?: string[];
   minVersion?: string;
@@ -47,13 +47,13 @@ interface Options {
   nbSolutions: number;
 }
 
-function validate(options: Options) {
+function validate(options: CliOptions) {
   if ((!options.modId || options.modId.length === 0) && (!options.modFile || options.modFile.length === 0)) {
     throw new Error('At least one --mod-id or --mod-file is required.');
   }
 }
 
-async function getModIds(modQueryService: ModQueryService, options: Options): Promise<string[]> {
+async function getModIds(modQueryService: ModQueryService, options: CliOptions): Promise<string[]> {
   let modIds = [...(options.modId ?? [])];
 
   if (options.modFile) {
@@ -97,7 +97,7 @@ program
   .option('--loader <loader...>', 'Loaders to consider (e.g., forge, fabric)', [])
   .option('-d, --details', 'Include details (e.g. unsupported mods in solutions found)')
   .option('-n, --nb-solutions <number>', 'Number of solutions to output', (value) => parseInt(value, 10), 3)
-  .action(async (cliOptions: Options) => {
+  .action(async (cliOptions: CliOptions) => {
 
     let modQueryService = getModQueryService();
     validate(cliOptions);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -9,6 +9,9 @@ import pino from 'pino';
 const LOG_LEVEL = (process.env.LOG_LEVEL ?? "info") as LogLevel;
 const logger = pino({
   level: LOG_LEVEL,
+  base: {
+    pid: false,
+  },
   transport: {
     target: 'pino-pretty',
     options: {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -44,6 +44,7 @@ interface Options {
   maxVersion?: string;
   loader?: string[];
   details?: boolean;
+  nbSolutions: number;
 }
 
 function validate(options: Options) {
@@ -95,6 +96,7 @@ program
   .option('--max-version <version>', 'Maximum Minecraft version to consider')
   .option('--loader <loader...>', 'Loaders to consider (e.g., forge, fabric)', [])
   .option('-d, --details', 'Include details (e.g. unsupported mods in solutions found)')
+  .option('-n, --nb-solutions <number>', 'Number of solutions to output', (value) => parseInt(value, 10), 3)
   .action(async (cliOptions: Options) => {
 
     let modQueryService = getModQueryService();
@@ -113,7 +115,7 @@ program
       minVersion: cliOptions.minVersion,
       maxVersion: cliOptions.maxVersion,
       loaders: cliOptions.loader as ModLoader[] | undefined,
-    });
+    }, cliOptions.nbSolutions);
 
     if (solutions.length === 0) {
       logger.info('No solutions found.');

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -2,6 +2,7 @@
 
 import { program } from '@commander-js/extra-typings';
 import { CurseForgeRepository, LocalSolutionFinder, LoggerConfig, ModLoader, ModQueryService, ModrinthRepository, LogLevel, Constraints } from 'mclib';
+import { readFileSync } from 'fs';
 
 LoggerConfig.setLevel((process.env.LOG_LEVEL ?? "info") as LogLevel);
 
@@ -15,15 +16,41 @@ function getModQueryService() {
 
 interface Options {
   modId?: string[];
+  modFile?: string[];
   minVersion?: string;
   maxVersion?: string;
   loader?: string[];
 }
 
-function validate(modQueryService: ModQueryService, options: Options) {
-  if (!options.modId || options.modId.length === 0) {
-    throw new Error('At least one --mod-id is required.');
+function validate(options: Options) {
+  if ((!options.modId || options.modId.length === 0) && (!options.modFile || options.modFile.length === 0)) {
+    throw new Error('At least one --mod-id or --mod-file is required.');
   }
+}
+
+async function getModIds(modQueryService: ModQueryService, options: Options): Promise<string[]> {
+  let modIds = [...(options.modId ?? [])];
+  
+  if (options.modFile) {
+    for (const file of options.modFile) {
+      try {
+        console.log(`Reading mod file: ${file}`);
+        const modData = readFileSync(file);
+        const modMetadata = await modQueryService.getModByDataHash(new Uint8Array(modData));
+        
+        if (modMetadata) {
+          modIds.push(modMetadata.id);
+          console.log(`Found mod ID ${modMetadata.id} from file: ${file}`);
+        } else {
+          console.warn(`Could not extract mod ID from file: ${file}`);
+        }
+      } catch (error) {
+        console.error(`Error reading file ${file}:`, error);
+      }
+    }
+  }
+  
+  return modIds;
 }
 
 program
@@ -35,17 +62,25 @@ program
   .command('find-solutions').alias('fs')
   .description('Find mod versions that match constraints')
   .option('--mod-id <modID...>', 'Mod IDs to include in the modpack')
+  .option('--mod-file <path...>', 'Mod IDs to include in the modpack')
   .option('--min-version <version>', 'Minimum Minecraft version to consider')
   .option('--max-version <version>', 'Maximum Minecraft version to consider')
   .option('--loader <loader...>', 'Loaders to consider (e.g., forge, fabric)', [])
   .action(async (cliOptions: Options) => {
 
     let modQueryService = getModQueryService();
-    validate(modQueryService, cliOptions);
+    validate(cliOptions);
+    
+    const modIds = await getModIds(modQueryService, cliOptions);
+    
+    if (modIds.length === 0) {
+      console.error('No valid mod IDs found from provided options.');
+      return;
+    }
 
-    console.log(`Searching for solutions..`);
+    console.log(`Searching for solutions with ${modIds.length} mod(s)...`);
     let solutionFinder = new LocalSolutionFinder(modQueryService);
-    let solutions = await solutionFinder.findSolutions(cliOptions.modId!, {
+    let solutions = await solutionFinder.findSolutions(modIds, {
       minVersion: cliOptions.minVersion,
       maxVersion: cliOptions.maxVersion,
       loaders: cliOptions.loader as ModLoader[] | undefined,
@@ -58,7 +93,7 @@ program
 
     console.log(`Found ${solutions.length} solution(s):`);
     for (const solution of solutions) {
-      console.log(`- Version: ${solution.mcConfig.mcVersion}, Loader: ${solution.mcConfig.loader}, Mods: ${solution.mods.length}/${cliOptions.modId?.length}`);
+      console.log(`- Version: ${solution.mcConfig.mcVersion}, Loader: ${solution.mcConfig.loader}, Mods: ${solution.mods.length}/${modIds.length}`);
     }
   });
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -44,9 +44,9 @@ interface CliOptions {
   minVersion?: string;
   maxVersion?: string;
   loader?: string[];
-  details?: boolean;
+  details: boolean;
   nbSolutions: number;
-  sinytra?: boolean;
+  sinytra: boolean;
 }
 
 function validateCliOptions(options: CliOptions) {
@@ -145,9 +145,9 @@ program
   .option('--min-version <version>', 'Minimum Minecraft version to consider')
   .option('--max-version <version>', 'Maximum Minecraft version to consider')
   .option('--loader <loader...>', 'Loaders to consider (e.g., forge, fabric)', [])
-  .option('-d, --details', 'Include details (e.g. unsupported mods in solutions found)')
+  .option('-d, --details', 'Include details (e.g. unsupported mods in solutions found)', false)
   .option('-n, --nb-solutions <number>', 'Number of solutions to output', (value) => parseInt(value, 10), 3)
-  .option('--sinytra', 'Inject forge and neoforge into fabric-compatible releases')
+  .option('--sinytra', 'Inject forge and neoforge into fabric-compatible releases', false)
   .action(async (cliOptions: CliOptions & { sinytra?: boolean }) => {
     let modQueryService = getModQueryService();
     validateCliOptions(cliOptions);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -72,7 +72,7 @@ async function getModIds(modQueryService: ModQueryService, options: Options): Pr
           logger.warn(`Could not extract mod ID from file: ${file}`);
         }
       } catch (error) {
-        logger.error(`Error reading file ${file}:`, error);
+        logger.error(`Error reading file ${file}: ${error}`);
       }
     }
   }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -127,7 +127,7 @@ program
       logger.info(`- Version: ${solution.mcConfig.mcVersion}, Loader: ${solution.mcConfig.loader}, Mods: ${solution.mods.length}/${requestedModIds.length}`);
       if (cliOptions.details && solution.mods.length != requestedModIds.length) {
         logger.info(`  Unsupported mods:`);
-        let unsupportedMods = requestedModIds.filter(modId => !solution.mods.some(mod => mod.name === modId));
+        let unsupportedMods = requestedModIds.filter(modId => !solution.mods.some(mod => mod.id === modId));
         for (const modId of unsupportedMods) {
           logger.info(`  - ${modId}`);
         }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -8,25 +8,25 @@ import pino from 'pino';
 // Logging setup
 const LOG_LEVEL = (process.env.LOG_LEVEL ?? "info") as LogLevel;
 const logger = pino({
-    level: LOG_LEVEL,
-    transport: {
-        target: 'pino-pretty',
-        options: {
-            colorize: true
-        }
+  level: LOG_LEVEL,
+  transport: {
+    target: 'pino-pretty',
+    options: {
+      colorize: true
     }
+  }
 });
 LoggerConfig.setLevel(LOG_LEVEL);
 
 async function timedFetch(input: RequestInfo | URL, options?: RequestInit): Promise<Response> {
-    const start = Date.now();
-    const response = await fetch(input, options);
-    const duration = Date.now() - start;
-    logger.debug(`fetch(${input}): ${duration}ms`);
-    if (!response.ok) {
-        logger.error(`Fetch failed for ${input}: ${response.status} ${response.statusText}`);
-    }
-    return response;
+  const start = Date.now();
+  const response = await fetch(input, options);
+  const duration = Date.now() - start;
+  logger.debug(`fetch(${input}): ${duration}ms`);
+  if (!response.ok) {
+    logger.error(`Fetch failed for ${input}: ${response.status} ${response.statusText}`);
+  }
+  return response;
 }
 
 function getModQueryService() {
@@ -53,7 +53,7 @@ function validate(options: Options) {
 
 async function getModIds(modQueryService: ModQueryService, options: Options): Promise<string[]> {
   let modIds = [...(options.modId ?? [])];
-  
+
   if (options.modFile) {
     for (const file of options.modFile) {
       try {
@@ -64,7 +64,7 @@ async function getModIds(modQueryService: ModQueryService, options: Options): Pr
         logger.debug(`readFileSync(${file}): ${duration}ms`);
 
         const modMetadata = await modQueryService.getModByDataHash(new Uint8Array(modData));
-        
+
         if (modMetadata) {
           modIds.push(modMetadata.id);
           logger.info(`Found mod ID ${modMetadata.id} from file: ${file}`);
@@ -76,7 +76,7 @@ async function getModIds(modQueryService: ModQueryService, options: Options): Pr
       }
     }
   }
-  
+
   return modIds;
 }
 
@@ -97,9 +97,9 @@ program
 
     let modQueryService = getModQueryService();
     validate(cliOptions);
-    
+
     const modIds = await getModIds(modQueryService, cliOptions);
-    
+
     if (modIds.length === 0) {
       logger.error('No valid mod IDs found from provided options.');
       return;

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -57,8 +57,12 @@ async function getModIds(modQueryService: ModQueryService, options: Options): Pr
   if (options.modFile) {
     for (const file of options.modFile) {
       try {
-        logger.debug("Reading mod file %s", file);
+
+        const start = Date.now();
         const modData = readFileSync(file);
+        const duration = Date.now() - start;
+        logger.debug(`readFileSync(${file}): ${duration}ms`);
+
         const modMetadata = await modQueryService.getModByDataHash(new Uint8Array(modData));
         
         if (modMetadata) {

--- a/mclib/package.json
+++ b/mclib/package.json
@@ -10,7 +10,8 @@
     "typescript-eslint": "^8.32.1"
   },
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "test": "bunx vitest run"
   },
   "type": "module",
   "types": "dist/index.d.ts",

--- a/mclib/package.json
+++ b/mclib/package.json
@@ -15,7 +15,7 @@
   "type": "module",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "cf-fingerprint": "https://github.com/arschedev/cf-fingerprint",
+    "cf-fingerprint": "https://github.com/iTrooz/cf-fingerprint/",
     "pino": "^9.7.0",
     "pino-pretty": "^13.0.0"
   }

--- a/mclib/package.json
+++ b/mclib/package.json
@@ -15,6 +15,8 @@
   "type": "module",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "cf-fingerprint": "https://github.com/arschedev/cf-fingerprint"
+    "cf-fingerprint": "https://github.com/arschedev/cf-fingerprint",
+    "pino": "^9.7.0",
+    "pino-pretty": "^13.0.0"
   }
 }

--- a/mclib/src/ModQueryService.ts
+++ b/mclib/src/ModQueryService.ts
@@ -67,4 +67,18 @@ export class ModQueryService {
         }
         throw new Error(`Mod with ID ${modId} not found in any repository`);
     }
+
+    async getModByDataHash(modData: Uint8Array): Promise<ModSearchMetadata | undefined> {
+        for (const repo of this.repositories) {
+            try {
+                const result = await repo.getByDataHash(modData);
+                if (result) {
+                    return result;
+                }
+            } catch (error) {
+                console.error(`Error fetching mod by hash from ${repo.getRepositoryName()}:`, error);
+            }
+        }
+        return undefined; // No mod found in any repository
+    }
 }

--- a/mclib/src/ModQueryService.ts
+++ b/mclib/src/ModQueryService.ts
@@ -71,19 +71,20 @@ export class ModQueryService {
 
     async getModByDataHash(modData: Uint8Array): Promise<ModSearchMetadata | undefined> {
         for (const repo of this.repositories) {
-            logger.debug("Trying to query mod id from data using repository %s", repo.getRepositoryName())
+            logger.debug("getModByDataHash(size = %s, %s)", modData.length, repo.getRepositoryName())
             try {
                 const result = await repo.getByDataHash(modData);
                 if (result) {
-                    logger.debug("Success");
+                    logger.debug("getModByDataHash(size = %s, %s) = %s (%s)", modData.length, repo.getRepositoryName(), result.id, result.name);
                     return result;
                 } else {
-                    logger.debug("Failure (not found)");
+                    logger.trace("getModByDataHash(size = %s, %s) = not found", modData.length, repo.getRepositoryName());
                 }
             } catch (error) {
                 logger.error("Error fetching mod by hash from %s: %s", repo.getRepositoryName(), error);
             }
         }
+        logger.debug("getModByDataHash(size = %s) = not found in any repository", modData.length);
         return undefined; // No mod found in any repository
     }
 }

--- a/mclib/src/ModQueryService.ts
+++ b/mclib/src/ModQueryService.ts
@@ -1,4 +1,5 @@
 import type { MCVersion, ModAndReleases, ModRepositoryName, ModSearchMetadata, IRepository } from ".";
+import { logger } from "./logger";
 
 export class ModQueryService {
 
@@ -70,13 +71,17 @@ export class ModQueryService {
 
     async getModByDataHash(modData: Uint8Array): Promise<ModSearchMetadata | undefined> {
         for (const repo of this.repositories) {
+            logger.debug("Trying to query mod id from data using repository %s", repo.getRepositoryName())
             try {
                 const result = await repo.getByDataHash(modData);
                 if (result) {
+                    logger.debug("Success");
                     return result;
+                } else {
+                    logger.debug("Failure (not found)");
                 }
             } catch (error) {
-                console.error(`Error fetching mod by hash from ${repo.getRepositoryName()}:`, error);
+                logger.error("Error fetching mod by hash from %s: %s", repo.getRepositoryName(), error);
             }
         }
         return undefined; // No mod found in any repository

--- a/mclib/src/finder/ISolutionFinder.ts
+++ b/mclib/src/finder/ISolutionFinder.ts
@@ -1,4 +1,4 @@
-import { Constraints, Solution } from "..";
+import { Constraints, ModAndReleases, Solution } from "..";
 
 export interface ISolutionFinder {
     /**
@@ -10,4 +10,19 @@ export interface ISolutionFinder {
      * @returns Array of solutions
      */
     findSolutions(mods: string[], constraints?: Constraints, nbSolution?: number): Promise<Solution[]>;
+
+    /**
+     * Resolves mod IDs to their releases metadata
+     * @param modIds List of mod IDs to resolve
+     * @returns Array of ModAndReleases objects
+     */
+    resolveMods(modIds: string[]): Promise<ModAndReleases[]>;
+
+    /**
+     * Finds the best Minecraft configurations (version + loader) that satisfy all mods
+     * @param mods List of mods with their releases
+     * @param nbSolution Maximum number of solutions to return
+     * @returns Array of compatible solutions
+     */
+    resolveSolutions(mods: ModAndReleases[], constraints: Constraints, nbSolution: number): Solution[];
 }

--- a/mclib/src/finder/ISolutionFinder.ts
+++ b/mclib/src/finder/ISolutionFinder.ts
@@ -1,4 +1,4 @@
-import { Constraints, ModAndReleases, Solution } from "..";
+import { Constraints, ModMetadata, ModReleases, Solution } from "..";
 
 export interface ISolutionFinder {
     /**
@@ -9,15 +9,15 @@ export interface ISolutionFinder {
      * @param nbSolutions Max number of solutions to return
      * @returns Array of solutions
      */
-    findSolutions(modIds: string[], constraints?: Constraints, nbSolutions?: number): Promise<Solution[]>;
+    findSolutions(modIds: ModMetadata[], constraints?: Constraints, nbSolutions?: number): Promise<Solution[]>;
 
     /**
      * Resolves releases of mods
      */
-    resolveMods(modIds: string[]): Promise<ModAndReleases[]>;
+    resolveMods(modIds: ModMetadata[]): Promise<ModReleases[]>;
 
     /**
      * Finds the best Minecraft configurations (version + loader) that satisfy all mods
      */
-    resolveSolutions(mods: ModAndReleases[], constraints: Constraints, nbSolution: number): Solution[];
+    resolveSolutions(mods: ModReleases[], constraints: Constraints, nbSolution: number): Solution[];
 }

--- a/mclib/src/finder/ISolutionFinder.ts
+++ b/mclib/src/finder/ISolutionFinder.ts
@@ -4,25 +4,20 @@ export interface ISolutionFinder {
     /**
      * Download releases for all mods, and return solutions that try to satisfy the constraints (Best solutions are returned first)
      * This is the method you should use for the main functionality of the class.
-     * @param mods List of mod IDs
+     * @param modIds List of mod IDs
      * @param constraints Constraints to apply on the solution
-     * @param nbSolution Max number of solutions to return
+     * @param nbSolutions Max number of solutions to return
      * @returns Array of solutions
      */
-    findSolutions(mods: string[], constraints?: Constraints, nbSolution?: number): Promise<Solution[]>;
+    findSolutions(modIds: string[], constraints?: Constraints, nbSolutions?: number): Promise<Solution[]>;
 
     /**
-     * Resolves mod IDs to their releases metadata
-     * @param modIds List of mod IDs to resolve
-     * @returns Array of ModAndReleases objects
+     * Resolves releases of mods
      */
     resolveMods(modIds: string[]): Promise<ModAndReleases[]>;
 
     /**
      * Finds the best Minecraft configurations (version + loader) that satisfy all mods
-     * @param mods List of mods with their releases
-     * @param nbSolution Maximum number of solutions to return
-     * @returns Array of compatible solutions
      */
     resolveSolutions(mods: ModAndReleases[], constraints: Constraints, nbSolution: number): Solution[];
 }

--- a/mclib/src/finder/LocalSolutionFinder.test.ts
+++ b/mclib/src/finder/LocalSolutionFinder.test.ts
@@ -84,10 +84,10 @@ describe('SolutionFinder', () => {
     describe('matchConstraints', () => {
         function createRelease(overrides: Partial<ModRelease> = {}): ModRelease {
             return {
-                mcVersions: ['1.16.5', '1.17.1'],
+                mcVersions: new Set(['1.16.5', '1.17.1']),
                 modVersion: '1.0.0',
                 repository: ModRepositoryName.MODRINTH,
-                loaders: [ModLoader.FORGE, ModLoader.FABRIC],
+                loaders: new Set([ModLoader.FORGE, ModLoader.FABRIC]),
                 ...overrides
             };
         }
@@ -106,25 +106,25 @@ describe('SolutionFinder', () => {
 
         describe('loader constraints', () => {
             it('matches when release supports one of the specified loaders', () => {
-                const release = createRelease({ loaders: [ModLoader.FORGE, ModLoader.FABRIC] });
+                const release = createRelease({ loaders: new Set([ModLoader.FORGE, ModLoader.FABRIC]) });
 
-                expect(matchConstraints(release, { loaders: [ModLoader.FORGE] })).toBe(true);
-                expect(matchConstraints(release, { loaders: [ModLoader.FABRIC] })).toBe(true);
-                expect(matchConstraints(release, { loaders: [ModLoader.FORGE, ModLoader.QUILT] })).toBe(true);
+                expect(matchConstraints(release, { loaders: new Set([ModLoader.FORGE]) })).toBe(true);
+                expect(matchConstraints(release, { loaders: new Set([ModLoader.FABRIC]) })).toBe(true);
+                expect(matchConstraints(release, { loaders: new Set([ModLoader.FORGE, ModLoader.QUILT]) })).toBe(true);
             });
 
             it('does not match when release does not support any of the specified loaders', () => {
-                const release = createRelease({ loaders: [ModLoader.FORGE, ModLoader.FABRIC] });
+                const release = createRelease({ loaders: new Set([ModLoader.FORGE, ModLoader.FABRIC]) });
 
-                expect(matchConstraints(release, { loaders: [ModLoader.QUILT] })).toBe(false);
-                expect(matchConstraints(release, { loaders: [ModLoader.NEOFORGE] })).toBe(false);
-                expect(matchConstraints(release, { loaders: [ModLoader.QUILT, ModLoader.NEOFORGE] })).toBe(false);
+                expect(matchConstraints(release, { loaders: new Set([ModLoader.QUILT]) })).toBe(false);
+                expect(matchConstraints(release, { loaders: new Set([ModLoader.NEOFORGE]) })).toBe(false);
+                expect(matchConstraints(release, { loaders: new Set([ModLoader.QUILT, ModLoader.NEOFORGE]) })).toBe(false);
             });
         });
 
         describe('minimal version constraints', () => {
             it('matches when release supports a version greater than or equal to minimal version', () => {
-                const release = createRelease({ mcVersions: ['1.16.5', '1.17.1'] });
+                const release = createRelease({ mcVersions: new Set(['1.16.5', '1.17.1']) });
 
                 expect(matchConstraints(release, { minVersion: '1.16.0' })).toBe(true);
                 expect(matchConstraints(release, { minVersion: '1.16.5' })).toBe(true);
@@ -133,7 +133,7 @@ describe('SolutionFinder', () => {
             });
 
             it('does not match when release does not support a version greater than or equal to minimal version', () => {
-                const release = createRelease({ mcVersions: ['1.16.5', '1.17.1'] });
+                const release = createRelease({ mcVersions: new Set(['1.16.5', '1.17.1']) });
 
                 expect(matchConstraints(release, { minVersion: '1.18.0' })).toBe(false);
             });
@@ -142,41 +142,41 @@ describe('SolutionFinder', () => {
         describe('combined constraints', () => {
             it('matches when release satisfies all constraints', () => {
                 const release = createRelease({
-                    mcVersions: ['1.16.5', '1.17.1'],
-                    loaders: [ModLoader.FORGE, ModLoader.FABRIC]
+                    mcVersions: new Set(['1.16.5', '1.17.1']),
+                    loaders: new Set([ModLoader.FORGE, ModLoader.FABRIC])
                 });
 
                 expect(matchConstraints(release, {
                     maxVersion: '1.16.5',
-                    loaders: [ModLoader.FORGE]
+                    loaders: new Set([ModLoader.FORGE])
                 })).toBe(true);
 
                 expect(matchConstraints(release, {
                     minVersion: '1.16.0',
-                    loaders: [ModLoader.FABRIC]
+                    loaders: new Set([ModLoader.FABRIC])
                 })).toBe(true);
 
                 expect(matchConstraints(release, {
                     minVersion: '1.16.0',
                     maxVersion: '1.17.1',
-                    loaders: [ModLoader.FORGE]
+                    loaders: new Set([ModLoader.FORGE])
                 })).toBe(true);
             });
 
             it('does not match when release fails any constraint', () => {
                 const release = createRelease({
-                    mcVersions: ['1.16.5', '1.17.1'],
-                    loaders: [ModLoader.FORGE, ModLoader.FABRIC]
+                    mcVersions: new Set(['1.16.5', '1.17.1']),
+                    loaders: new Set([ModLoader.FORGE, ModLoader.FABRIC])
                 });
 
                 expect(matchConstraints(release, {
                     maxVersion: '1.15.2',
-                    loaders: [ModLoader.QUILT]
+                    loaders: new Set([ModLoader.QUILT])
                 })).toBe(false);
 
                 expect(matchConstraints(release, {
                     minVersion: '1.18.0',
-                    loaders: [ModLoader.FORGE]
+                    loaders: new Set([ModLoader.FORGE])
                 })).toBe(false);
             });
         });
@@ -193,16 +193,16 @@ describe('SolutionFinder', () => {
                 id: 'jei',
                 releases: [
                     {
-                        mcVersions: ['1.17.1', '1.18.1'],
+                        mcVersions: new Set(['1.17.1', '1.18.1']),
                         modVersion: '9.0.0',
                         repository: ModRepositoryName.MODRINTH,
-                        loaders: [ModLoader.FORGE, ModLoader.FABRIC]
+                        loaders: new Set([ModLoader.FORGE, ModLoader.FABRIC])
                     },
                     {
-                        mcVersions: ['1.16.5'],
+                        mcVersions: new Set(['1.16.5']),
                         modVersion: '8.0.0',
                         repository: ModRepositoryName.MODRINTH,
-                        loaders: [ModLoader.FORGE, ModLoader.FABRIC]
+                        loaders: new Set([ModLoader.FORGE, ModLoader.FABRIC])
                     }
                 ]
             };
@@ -211,22 +211,22 @@ describe('SolutionFinder', () => {
                 id: 'ice-and-fire-dragons',
                 releases: [
                     {
-                        mcVersions: ['1.16.5', '1.17.1'],
+                        mcVersions: new Set(['1.16.5', '1.17.1']),
                         modVersion: '2.0.0',
                         repository: ModRepositoryName.MODRINTH,
-                        loaders: [ModLoader.FORGE]
+                        loaders: new Set([ModLoader.FORGE])
                     },
                     {
-                        mcVersions: ['1.12.2'],
+                        mcVersions: new Set(['1.12.2']),
                         modVersion: '1.0.0',
                         repository: ModRepositoryName.MODRINTH,
-                        loaders: [ModLoader.FORGE]
+                        loaders: new Set([ModLoader.FORGE])
                     },
                     {
-                        mcVersions: ['1.16.5', '1.17.1', '1.18.1'],
+                        mcVersions: new Set(['1.16.5', '1.17.1', '1.18.1']),
                         modVersion: '2.0.0',
                         repository: ModRepositoryName.MODRINTH,
-                        loaders: [ModLoader.FABRIC]
+                        loaders: new Set([ModLoader.FABRIC])
                     }
                 ]
             };
@@ -274,7 +274,7 @@ describe('SolutionFinder', () => {
         });
 
         it('should respect loader constraints', async () => {
-            const result = (await solutionFinder.findSolutions(['ice-and-fire-dragons'], { loaders: [ModLoader.FORGE] }))[0];
+            const result = (await solutionFinder.findSolutions(['ice-and-fire-dragons'], { loaders: new Set([ModLoader.FORGE]) }))[0];
             expect(result.mcConfig.loader).toBe(ModLoader.FORGE);
             expect(result.mcConfig.mcVersion).toBe('1.17.1');
             expect(result.mods[0].release.loaders).toContain(ModLoader.FORGE);
@@ -289,7 +289,7 @@ describe('SolutionFinder', () => {
             const constraints: Constraints = {
                 minVersion: '1.12.2',
                 maxVersion: '1.12.2',
-                loaders: [ModLoader.FABRIC]
+                loaders: new Set([ModLoader.FABRIC])
             };
             const result = await solutionFinder.findSolutions(['ice-and-fire-dragons'], constraints, 1);
             expect(result).toHaveLength(0);
@@ -301,10 +301,10 @@ describe('SolutionFinder', () => {
             const secondRepoMod: ModAndReleases = {
                 id: 'second-repo-mod',
                 releases: [{
-                    mcVersions: ['1.17.1'],
+                    mcVersions: new Set(['1.17.1']),
                     modVersion: '1.0.0',
                     repository: ModRepositoryName.CURSEFORGE,
-                    loaders: [ModLoader.FABRIC]
+                    loaders: new Set([ModLoader.FABRIC])
                 }]
             };
             secondMockRepo.setMod('second-repo-mod', secondRepoMod);

--- a/mclib/src/finder/LocalSolutionFinder.test.ts
+++ b/mclib/src/finder/LocalSolutionFinder.test.ts
@@ -190,7 +190,7 @@ describe('SolutionFinder', () => {
             mockRepository = new MockRepository();
 
             const jeiMod: ModAndReleases = {
-                name: 'Just Enough Items',
+                id: 'jei',
                 releases: [
                     {
                         mcVersions: ['1.17.1', '1.18.1'],
@@ -208,7 +208,7 @@ describe('SolutionFinder', () => {
             };
 
             const dragonsMod: ModAndReleases = {
-                name: 'Ice and Fire: Dragons',
+                id: 'ice-and-fire-dragons',
                 releases: [
                     {
                         mcVersions: ['1.16.5', '1.17.1'],
@@ -254,7 +254,7 @@ describe('SolutionFinder', () => {
                 loader: ModLoader.FABRIC
             });
             expect(result.mods).toHaveLength(1);
-            expect(result.mods[0].name).toBe('Ice and Fire: Dragons');
+            expect(result.mods[0].id).toBe('ice-and-fire-dragons');
             expect(result.mods[0].release.modVersion).toBe('2.0.0');
         });
 
@@ -268,9 +268,9 @@ describe('SolutionFinder', () => {
                 loader: ModLoader.FABRIC
             });
             expect(result.mods).toHaveLength(2);
-            const modNames = result.mods.map(mod => mod.name);
-            expect(modNames).toContain('Ice and Fire: Dragons');
-            expect(modNames).toContain('Just Enough Items');
+            const modIds = result.mods.map(mod => mod.id);
+            expect(modIds).toContain('ice-and-fire-dragons');
+            expect(modIds).toContain('jei');
         });
 
         it('should respect loader constraints', async () => {
@@ -299,7 +299,7 @@ describe('SolutionFinder', () => {
             // Setup second repository
             const secondMockRepo = new MockRepository();
             const secondRepoMod: ModAndReleases = {
-                name: 'Second Repo Mod',
+                id: 'second-repo-mod',
                 releases: [{
                     mcVersions: ['1.17.1'],
                     modVersion: '1.0.0',
@@ -313,9 +313,9 @@ describe('SolutionFinder', () => {
             const result = (await solutionFinder.findSolutions(['ice-and-fire-dragons', 'second-repo-mod']))[0];
 
             expect(result.mods).toHaveLength(2);
-            const modNames = result.mods.map(mod => mod.name);
-            expect(modNames).toContain('Ice and Fire: Dragons');
-            expect(modNames).toContain('Second Repo Mod');
+            const modIds = result.mods.map(mod => mod.id);
+            expect(modIds).toContain('ice-and-fire-dragons');
+            expect(modIds).toContain('second-repo-mod');
             expect(result.mcConfig.mcVersion).toBe('1.17.1');
             expect(result.mcConfig.loader).toBe(ModLoader.FABRIC);
         });

--- a/mclib/src/finder/LocalSolutionFinder.ts
+++ b/mclib/src/finder/LocalSolutionFinder.ts
@@ -30,7 +30,7 @@ export class LocalSolutionFinder implements ISolutionFinder {
         logger.debug("%s releases after flattening", flatReleases.length);
 
         // Filter releases based on constraints
-        const matchingReleases = flatReleases.filter(({ id, release }) =>
+        const matchingReleases = flatReleases.filter(({ release }) =>
             this.matchConstraints(release, constraints)
         );
         logger.debug("%s releases match constraints", matchingReleases.length);
@@ -91,7 +91,7 @@ export class LocalSolutionFinder implements ISolutionFinder {
 
         let releaseCount = 0;
         for (const modId of modIds) {
-            let releases = await this.query.getModReleases(modId);
+            const releases = await this.query.getModReleases(modId);
             releaseCount += releases.releases.length;
             resolvedMods.push(releases);
         }

--- a/mclib/src/finder/LocalSolutionFinder.ts
+++ b/mclib/src/finder/LocalSolutionFinder.ts
@@ -14,12 +14,6 @@ export class LocalSolutionFinder implements ISolutionFinder {
         this.query = modQueryService;
     }
 
-    /**
-     * Download releases metadata for all mods, and return solutions that try to satisfy the constraints (Best solutions are returned first)
-     * This is the method you should use for the main functionality of the class.
-     * @param nbSolution Number of solutions to return
-     * @returns Array of compatible solutions
-     */
     async findSolutions(mods: string[], constraints: Constraints = {}, nbSolution: number = 5): Promise<Solution[]> {
         logger.debug("findSolutions()");
         const resolvedMods = await this.resolveMods(mods);
@@ -28,13 +22,7 @@ export class LocalSolutionFinder implements ISolutionFinder {
         return solutions;
     }
 
-    /**
-     * Finds the best Minecraft configurations (version + loader) that satisfy all mods
-     * @param mods List of mods with their releases
-     * @param nbSolution Maximum number of solutions to return
-     * @returns Array of compatible solutions
-     */
-    private resolveSolutions(mods: ModAndReleases[], constraints: Constraints, nbSolution: number): Solution[] {
+    resolveSolutions(mods: ModAndReleases[], constraints: Constraints, nbSolution: number): Solution[] {
         logger.debug({ constraints }, "resolveSolutions(mods=%s)", mods.length);
 
         // Get flat list of all mod releases
@@ -97,7 +85,7 @@ export class LocalSolutionFinder implements ISolutionFinder {
         return solutions;
     }
 
-    private async resolveMods(modIds: string[]): Promise<ModAndReleases[]> {
+    async resolveMods(modIds: string[]): Promise<ModAndReleases[]> {
         logger.debug("resolveMods(mods=%s)", modIds.length);
         const resolvedMods: ModAndReleases[] = [];
 

--- a/mclib/src/finder/LocalSolutionFinder.ts
+++ b/mclib/src/finder/LocalSolutionFinder.ts
@@ -87,13 +87,13 @@ export class LocalSolutionFinder implements ISolutionFinder {
                 mods: matchingModReleases
             });
         }
-        logger.debug("resolveSolutions() = %s solutions", solutions.length);
         
         // Return top 'nbSolution' solutions
         solutions.sort((a, b) => {
             return b.mods.length - a.mods.length;
         });
         if (solutions.length > nbSolution) solutions.length = nbSolution; // Trim to nbSolution
+        logger.debug("resolveSolutions() = %s solutions (sizes: [%s])", solutions.length, solutions.map(s => s.mods.length).join(", "));
         return solutions;
     }
 

--- a/mclib/src/finder/LocalSolutionFinder.ts
+++ b/mclib/src/finder/LocalSolutionFinder.ts
@@ -81,7 +81,7 @@ export class LocalSolutionFinder implements ISolutionFinder {
             }
 
             // If we found a match for every mod, add this solution
-            logger.debug({config}, "Found solution with %d/%d matching mods", matchingModReleases.length, mods.length);
+            logger.trace({config}, "Found solution with %d/%d matching mods", matchingModReleases.length, mods.length);
             solutions.push({
                 mcConfig: config,
                 mods: matchingModReleases

--- a/mclib/src/finder/LocalSolutionFinder.ts
+++ b/mclib/src/finder/LocalSolutionFinder.ts
@@ -138,7 +138,7 @@ export class LocalSolutionFinder implements ISolutionFinder {
      */
     private matchConstraints(release: ModRelease, constraints: Constraints): boolean {
         // Check loader constraint
-        if (constraints.loaders && !constraints.loaders.some(l => release.loaders.includes(l))) {
+        if (constraints.loaders?.length && !constraints.loaders.some(l => release.loaders.includes(l))) {
             return false;
         }
 

--- a/mclib/src/finder/LocalSolutionFinder.ts
+++ b/mclib/src/finder/LocalSolutionFinder.ts
@@ -58,8 +58,8 @@ export class LocalSolutionFinder implements ISolutionFinder {
                 if (matchedModIds.has(mod.id)) continue;
 
                 // Check if this release matches the current config
-                if (release.mcVersions.includes(config.mcVersion) &&
-                    release.loaders.includes(config.loader)) {
+                if (release.mcVersions.has(config.mcVersion) &&
+                    release.loaders.has(config.loader)) {
                     matchingModReleases.push({
                         id: mod.id,
                         release: release
@@ -144,13 +144,13 @@ export class LocalSolutionFinder implements ISolutionFinder {
         logger.trace({ release, constraints }, "matchConstraints()");
 
         // Check loader constraint
-        if (constraints.loaders?.length && !constraints.loaders.some(l => release.loaders.includes(l))) {
+        if (constraints.loaders?.size && ![...constraints.loaders].some(l => release.loaders.has(l))) {
             return false;
         }
 
         // Check minimal version constraint
         if (constraints.minVersion) {
-            const hasVersionAboveMin = release.mcVersions.some(v => {
+            const hasVersionAboveMin = [...release.mcVersions].some(v => {
                 logger.trace({ version: v, minVersion: constraints.minVersion }, "compareVersions()")
                 return this.compareVersions(v, constraints.minVersion as string) >= 0
             }
@@ -162,7 +162,7 @@ export class LocalSolutionFinder implements ISolutionFinder {
 
         // Check maximal version constraint
         if (constraints.maxVersion) {
-            const hasVersionBelowMax = release.mcVersions.some(v =>
+            const hasVersionBelowMax = [...release.mcVersions].some(v =>
                 this.compareVersions(v, constraints.maxVersion as string) <= 0
             );
             if (!hasVersionBelowMax) {

--- a/mclib/src/finder/LocalSolutionFinder.ts
+++ b/mclib/src/finder/LocalSolutionFinder.ts
@@ -62,9 +62,6 @@ export class LocalSolutionFinder implements ISolutionFinder {
         // Find configs that have compatible releases for each mod
         logger.debug("Iterating over %d config candidates", configCandidates.length);
         for (const config of configCandidates) {
-            // Skip if we already have enough solutions
-            if (solutions.length >= nbSolution) break;
-
             const matchingModReleases: ModAndRelease[] = [];
             const matchedModNames = new Set<string>();
 
@@ -85,14 +82,18 @@ export class LocalSolutionFinder implements ISolutionFinder {
 
             // If we found a match for every mod, add this solution
             logger.debug({config}, "Found solution with %d/%d matching mods", matchingModReleases.length, mods.length);
-            if (matchedModNames.size === mods.length) {
-                solutions.push({
-                    mcConfig: config,
-                    mods: matchingModReleases
-                });
-            }
+            solutions.push({
+                mcConfig: config,
+                mods: matchingModReleases
+            });
         }
         logger.debug("resolveSolutions() = %s solutions", solutions.length);
+        
+        // Return top 'nbSolution' solutions
+        solutions.sort((a, b) => {
+            return b.mods.length - a.mods.length;
+        });
+        if (solutions.length > nbSolution) solutions.length = nbSolution; // Trim to nbSolution
         return solutions;
     }
 

--- a/mclib/src/finder/LocalSolutionFinder.ts
+++ b/mclib/src/finder/LocalSolutionFinder.ts
@@ -24,7 +24,7 @@ export class LocalSolutionFinder implements ISolutionFinder {
         logger.debug("findSolutions()");
         const resolvedMods = await this.resolveMods(mods);
         const solutions = this.resolveSolutions(resolvedMods, constraints, nbSolution);
-        logger.debug("findSolutions() = %s solutions", solutions.length);
+        logger.debug("findSolutions(): %s solutions", solutions.length);
         return solutions;
     }
 
@@ -93,18 +93,22 @@ export class LocalSolutionFinder implements ISolutionFinder {
             return b.mods.length - a.mods.length;
         });
         if (solutions.length > nbSolution) solutions.length = nbSolution; // Trim to nbSolution
-        logger.debug("resolveSolutions() = %s solutions (sizes: [%s])", solutions.length, solutions.map(s => s.mods.length).join(", "));
+        logger.debug("resolveSolutions(): %s solutions (sizes: [%s])", solutions.length, solutions.map(s => s.mods.length).join(", "));
         return solutions;
     }
 
     private async resolveMods(modIds: string[]): Promise<ModAndReleases[]> {
         logger.debug("resolveMods(mods=%s)", modIds.length);
         const resolvedMods: ModAndReleases[] = [];
-
+        
+        let releaseCount = 0;
         for (const modId of modIds) {
-            resolvedMods.push(await this.query.getModReleases(modId));
+            let releases = await this.query.getModReleases(modId);
+            releaseCount += releases.releases.length;
+            resolvedMods.push(releases);
         }
-
+        
+        logger.debug("resolveMods(mods=%s): %s total releases", modIds.length, releaseCount);
         return resolvedMods;
     }
 

--- a/mclib/src/finder/LocalSolutionFinder.ts
+++ b/mclib/src/finder/LocalSolutionFinder.ts
@@ -35,7 +35,7 @@ export class LocalSolutionFinder implements ISolutionFinder {
      * @returns Array of compatible solutions
      */
     private resolveSolutions(mods: ModAndReleases[], constraints: Constraints, nbSolution: number): Solution[] {
-        logger.debug({constraints}, "resolveSolutions(mods=%s)", mods.length);
+        logger.debug({ constraints }, "resolveSolutions(mods=%s)", mods.length);
 
         // Get flat list of all mod releases
         const flatReleases = this.getFlatReleases(mods);
@@ -81,13 +81,13 @@ export class LocalSolutionFinder implements ISolutionFinder {
             }
 
             // If we found a match for every mod, add this solution
-            logger.trace({config}, "Found solution with %d/%d matching mods", matchingModReleases.length, mods.length);
+            logger.trace({ config }, "Found solution with %d/%d matching mods", matchingModReleases.length, mods.length);
             solutions.push({
                 mcConfig: config,
                 mods: matchingModReleases
             });
         }
-        
+
         // Return top 'nbSolution' solutions
         solutions.sort((a, b) => {
             return b.mods.length - a.mods.length;
@@ -100,14 +100,14 @@ export class LocalSolutionFinder implements ISolutionFinder {
     private async resolveMods(modIds: string[]): Promise<ModAndReleases[]> {
         logger.debug("resolveMods(mods=%s)", modIds.length);
         const resolvedMods: ModAndReleases[] = [];
-        
+
         let releaseCount = 0;
         for (const modId of modIds) {
             let releases = await this.query.getModReleases(modId);
             releaseCount += releases.releases.length;
             resolvedMods.push(releases);
         }
-        
+
         logger.debug("resolveMods(mods=%s): %s total releases", modIds.length, releaseCount);
         return resolvedMods;
     }
@@ -153,7 +153,7 @@ export class LocalSolutionFinder implements ISolutionFinder {
      * @returns True if the release matches the constraints
      */
     private matchConstraints(release: ModRelease, constraints: Constraints): boolean {
-        logger.trace({release, constraints}, "matchConstraints()");
+        logger.trace({ release, constraints }, "matchConstraints()");
         // Check loader constraint
         logger.trace("AAAA");
         if (constraints.loaders?.length && !constraints.loaders.some(l => release.loaders.includes(l))) {
@@ -164,7 +164,7 @@ export class LocalSolutionFinder implements ISolutionFinder {
         // Check minimal version constraint
         if (constraints.minVersion) {
             const hasVersionAboveMin = release.mcVersions.some(v => {
-                logger.trace({version: v, minVersion: constraints.minVersion}, "compareVersions()")
+                logger.trace({ version: v, minVersion: constraints.minVersion }, "compareVersions()")
                 return this.compareVersions(v, constraints.minVersion as string) >= 0
             }
             );

--- a/mclib/src/finder/LocalSolutionFinder.ts
+++ b/mclib/src/finder/LocalSolutionFinder.ts
@@ -154,12 +154,11 @@ export class LocalSolutionFinder implements ISolutionFinder {
      */
     private matchConstraints(release: ModRelease, constraints: Constraints): boolean {
         logger.trace({ release, constraints }, "matchConstraints()");
+
         // Check loader constraint
-        logger.trace("AAAA");
         if (constraints.loaders?.length && !constraints.loaders.some(l => release.loaders.includes(l))) {
             return false;
         }
-        logger.trace("BBBB");
 
         // Check minimal version constraint
         if (constraints.minVersion) {

--- a/mclib/src/finder/LocalSolutionFinder.ts
+++ b/mclib/src/finder/LocalSolutionFinder.ts
@@ -63,20 +63,20 @@ export class LocalSolutionFinder implements ISolutionFinder {
         logger.debug("Iterating over %d config candidates", configCandidates.length);
         for (const config of configCandidates) {
             const matchingModReleases: ModAndRelease[] = [];
-            const matchedModNames = new Set<string>();
+            const matchedModIds = new Set<string>();
 
             for (const [mod, release] of matchingReleases) {
                 // Skip if we already found a release for this mod
-                if (matchedModNames.has(mod.name)) continue;
+                if (matchedModIds.has(mod.id)) continue;
 
                 // Check if this release matches the current config
                 if (release.mcVersions.includes(config.mcVersion) &&
                     release.loaders.includes(config.loader)) {
                     matchingModReleases.push({
-                        name: mod.name,
+                        id: mod.id,
                         release: release
                     });
-                    matchedModNames.add(mod.name);
+                    matchedModIds.add(mod.id);
                 }
             }
 
@@ -117,9 +117,9 @@ export class LocalSolutionFinder implements ISolutionFinder {
      * @param mods List of mods with their releases
      * @returns Flattened list of (mod, release) pairs
      */
-    private getFlatReleases(mods: ModAndReleases[]): Array<[{ name: string }, ModRelease]> {
+    private getFlatReleases(mods: ModAndReleases[]): Array<[{ id: string }, ModRelease]> {
         return mods.flatMap(mod =>
-            mod.releases.map(release => [{ name: mod.name }, release] as [{ name: string }, ModRelease])
+            mod.releases.map(release => [{ id: mod.id }, release] as [{ id: string }, ModRelease])
         );
     }
 
@@ -128,7 +128,7 @@ export class LocalSolutionFinder implements ISolutionFinder {
      * @param releases Flattened list of mod releases
      * @returns List of unique configuration candidates
      */
-    private extractConfigCandidates(releases: Array<[{ name: string }, ModRelease]>): MCConfig[] {
+    private extractConfigCandidates(releases: Array<[{ id: string }, ModRelease]>): MCConfig[] {
         const configs: MCConfig[] = [];
         const configSet = new Set<string>();
 

--- a/mclib/src/index.ts
+++ b/mclib/src/index.ts
@@ -7,6 +7,7 @@ export {
   Solution,
   ModSearchMetadata,
   Constraints,
+  ModLoaderUtil
 } from "./types";
 
 export type {

--- a/mclib/src/index.ts
+++ b/mclib/src/index.ts
@@ -5,22 +5,23 @@ export {
   ModSourceType,
   ModLoader,
   Solution,
-  ModSearchMetadata,
+  ModMetadata,
+  ModMetadataUtil,
+  ModRepoMetadata,
   Constraints,
   ModLoaderUtil
 } from "./types";
 
 export type {
   MCConfig,
-  ModAndRelease,
-  ModAndReleases,
-  ModRelease,
+  ModRepoRelease,
   MCVersion,
+  ModReleases
 } from "./types";
 
 export { ModQueryService } from "./ModQueryService";
 
-export { ModrinthRepository, CurseForgeRepository } from "./repos";
+export { ModrinthRepository, CurseForgeRepository, RepositoryUtil } from "./repos";
 export type { IRepository } from "./repos";
 
 export { LoggerConfig, LogLevel } from "./logger";

--- a/mclib/src/index.ts
+++ b/mclib/src/index.ts
@@ -21,3 +21,5 @@ export { ModQueryService } from "./ModQueryService";
 
 export { ModrinthRepository, CurseForgeRepository } from "./repos";
 export type { IRepository } from "./repos";
+
+export { LoggerConfig, LogLevel } from "./logger";

--- a/mclib/src/logger.ts
+++ b/mclib/src/logger.ts
@@ -11,6 +11,9 @@ export enum LogLevel {
 
 const logger = pino({
     level: 'info', // default level
+    base: {
+        pid: false,
+    },
     transport: {
         target: 'pino-pretty',
         options: {

--- a/mclib/src/logger.ts
+++ b/mclib/src/logger.ts
@@ -1,0 +1,28 @@
+import pino from 'pino';
+
+export enum LogLevel {
+    Fatal = 'fatal',
+    Error = 'error',
+    Warn = 'warn',
+    Info = 'info',
+    Debug = 'debug',
+    Trace = 'trace'
+}
+
+const logger = pino({
+    level: 'info', // default level
+    transport: {
+        target: 'pino-pretty',
+        options: {
+            colorize: true
+        }
+    }
+});
+
+class LoggerConfig {
+    static setLevel(level: LogLevel): void {
+        logger.level = level;
+    }
+}
+
+export { logger, LoggerConfig };

--- a/mclib/src/repos/CurseForgeRepository.ts
+++ b/mclib/src/repos/CurseForgeRepository.ts
@@ -21,10 +21,6 @@ export class CurseForgeRepository implements IRepository {
     }
 
     async getModReleases(modId: string): Promise<ModAndReleases> {
-        const modResp = await this.fetchClient(`${CurseForgeRepository.BASE_URL}/mods/${modId}`);
-        if (!modResp.ok) throw new Error("Mod not found on CurseForge");
-        const modData = (await modResp.json()).data;
-
         const filesResp = await this.fetchClient(`${CurseForgeRepository.BASE_URL}/mods/${modId}/files`);
         if (!filesResp.ok) throw new Error("Could not fetch files from CurseForge");
         const filesData = (await filesResp.json()).data;

--- a/mclib/src/repos/CurseForgeRepository.ts
+++ b/mclib/src/repos/CurseForgeRepository.ts
@@ -1,5 +1,5 @@
 import type { IRepository } from "./IRepository";
-import { ModAndReleases, ModRelease, ModRepositoryName, ModLoader, ModSearchMetadata } from "..";
+import { ModAndReleases, ModRelease, ModRepositoryName, ModLoader, ModSearchMetadata, MCVersion } from "..";
 import { cf_fingerprint } from 'cf-fingerprint';
 import { logger } from "../logger";
 
@@ -30,14 +30,14 @@ export class CurseForgeRepository implements IRepository {
         const filesData = (await filesResp.json()).data;
         
         const releases: ModRelease[] = filesData.map((file: any) => {
-            const mcVersions: string[] = [];
-            const loaders: ModLoader[] = [];
-            for (const d of file.gameVersions || []) {
-                const lower = d.toLowerCase();
-                if (/^[a-z]+$/.test(lower)) {
-                    loaders.push(lower as ModLoader);
+            const mcVersions: Set<MCVersion> = new Set();
+            const loaders: Set<ModLoader> = new Set();
+            for (let gameVersion of file.gameVersions || []) {
+                gameVersion = gameVersion.toLowerCase();
+                if (/^[a-z]+$/.test(gameVersion)) {
+                    loaders.add(ModLoader.from(gameVersion));
                 } else {
-                    mcVersions.push(lower);
+                    mcVersions.add(gameVersion);
                 }
             }
 

--- a/mclib/src/repos/CurseForgeRepository.ts
+++ b/mclib/src/repos/CurseForgeRepository.ts
@@ -50,7 +50,7 @@ export class CurseForgeRepository implements IRepository {
         });
 
         return {
-            name: modData.name,
+            id: modId,
             releases,
         };
     }

--- a/mclib/src/repos/CurseForgeRepository.ts
+++ b/mclib/src/repos/CurseForgeRepository.ts
@@ -1,5 +1,5 @@
 import type { IRepository } from "./IRepository";
-import { ModAndReleases, ModRelease, ModRepositoryName, ModLoader, ModSearchMetadata, MCVersion, ModLoaderUtil } from "..";
+import { ModRepoRelease, ModRepositoryName, ModLoader, ModRepoMetadata, MCVersion, ModLoaderUtil, ModReleases } from "..";
 import { cf_fingerprint } from 'cf-fingerprint';
 import { logger } from "../logger";
 
@@ -20,12 +20,12 @@ export class CurseForgeRepository implements IRepository {
         return null;
     }
 
-    async getModReleases(modId: string): Promise<ModAndReleases> {
+    async getModReleases(modId: string): Promise<ModReleases> {
         const filesResp = await this.fetchClient(`${CurseForgeRepository.BASE_URL}/mods/${modId}/files`);
         if (!filesResp.ok) throw new Error("Could not fetch files from CurseForge");
         const filesData = (await filesResp.json()).data;
 
-        const releases: ModRelease[] = filesData.map((file: any) => {
+        const releases: ModRepoRelease[] = filesData.map((file: any) => {
             const mcVersions: Set<MCVersion> = new Set();
             const loaders: Set<ModLoader> = new Set();
             for (let gameVersion of file.gameVersions || []) {
@@ -45,13 +45,10 @@ export class CurseForgeRepository implements IRepository {
             })
         });
 
-        return {
-            id: modId,
-            releases,
-        };
+        return releases;
     }
 
-    async searchMods(query: string, maxResults: number): Promise<ModSearchMetadata[]> {
+    async searchMods(query: string, maxResults: number): Promise<ModRepoMetadata[]> {
         const resp = await this.fetchClient(`${CurseForgeRepository.BASE_URL}/mods/search?` + new URLSearchParams({
             // params from PrismLancher
             gameId: "432", // Minecraft game ID
@@ -73,7 +70,7 @@ export class CurseForgeRepository implements IRepository {
         }));
     }
 
-    async getByDataHash(modData: Uint8Array): Promise<ModSearchMetadata | null> {
+    async getByDataHash(modData: Uint8Array): Promise<ModRepoMetadata | null> {
         // Calculate CurseForge fingerprint
         const start = Date.now();
         const fingerprint: number = cf_fingerprint(modData);
@@ -108,6 +105,7 @@ export class CurseForgeRepository implements IRepository {
 
         return {
             id: modId.toString(),
+            repository: ModRepositoryName.CURSEFORGE,
             name: modInfo.name,
             homepageURL: modInfo.links.websiteUrl,
             imageURL: modInfo.logo?.url || "",

--- a/mclib/src/repos/CurseForgeRepository.ts
+++ b/mclib/src/repos/CurseForgeRepository.ts
@@ -81,7 +81,7 @@ export class CurseForgeRepository implements IRepository {
         const fingerprint: number = cf_fingerprint(modData);
 
         // Use the CurseForge API to get file info by fingerprint
-        const resp = await fetch(`${CurseForgeRepository.BASE_URL}/fingerprints`, {
+        const resp = await this.fetchClient(`${CurseForgeRepository.BASE_URL}/fingerprints`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -102,7 +102,7 @@ export class CurseForgeRepository implements IRepository {
         const modId: number = fileMatch.file.modId;
 
         // Get mod info using the mod ID
-        const modResp = await fetch(`${CurseForgeRepository.BASE_URL}/mods/${modId}`);
+        const modResp = await this.fetchClient(`${CurseForgeRepository.BASE_URL}/mods/${modId}`);
         if (!modResp.ok) return null;
         const modInfo = (await modResp.json()).data;
 

--- a/mclib/src/repos/CurseForgeRepository.ts
+++ b/mclib/src/repos/CurseForgeRepository.ts
@@ -1,5 +1,5 @@
 import type { IRepository } from "./IRepository";
-import { ModAndReleases, ModRelease, ModRepositoryName, ModLoader, ModSearchMetadata, MCVersion } from "..";
+import { ModAndReleases, ModRelease, ModRepositoryName, ModLoader, ModSearchMetadata, MCVersion, ModLoaderUtil } from "..";
 import { cf_fingerprint } from 'cf-fingerprint';
 import { logger } from "../logger";
 
@@ -24,14 +24,14 @@ export class CurseForgeRepository implements IRepository {
         const filesResp = await this.fetchClient(`${CurseForgeRepository.BASE_URL}/mods/${modId}/files`);
         if (!filesResp.ok) throw new Error("Could not fetch files from CurseForge");
         const filesData = (await filesResp.json()).data;
-        
+
         const releases: ModRelease[] = filesData.map((file: any) => {
             const mcVersions: Set<MCVersion> = new Set();
             const loaders: Set<ModLoader> = new Set();
             for (let gameVersion of file.gameVersions || []) {
                 gameVersion = gameVersion.toLowerCase();
                 if (/^[a-z]+$/.test(gameVersion)) {
-                    loaders.add(ModLoader.from(gameVersion));
+                    loaders.add(ModLoaderUtil.from(gameVersion));
                 } else {
                     mcVersions.add(gameVersion);
                 }
@@ -95,7 +95,7 @@ export class CurseForgeRepository implements IRepository {
             return null;
         }
         const data = (await resp.json()).data;
-        
+
         if (!data.exactMatches || data.exactMatches.length === 0) return null;
 
         const fileMatch = data.exactMatches[0];

--- a/mclib/src/repos/CurseForgeRepository.ts
+++ b/mclib/src/repos/CurseForgeRepository.ts
@@ -1,6 +1,7 @@
 import type { IRepository } from "./IRepository";
 import { ModAndReleases, ModRelease, ModRepositoryName, ModLoader, ModSearchMetadata } from "..";
 import { cf_fingerprint } from 'cf-fingerprint';
+import { logger } from "../logger";
 
 /**
  * Implementation of IRepository for the CurseForge repository.
@@ -78,7 +79,10 @@ export class CurseForgeRepository implements IRepository {
 
     async getByDataHash(modData: Uint8Array): Promise<ModSearchMetadata | null> {
         // Calculate CurseForge fingerprint
+        const start = Date.now();
         const fingerprint: number = cf_fingerprint(modData);
+        const duration = Date.now() - start;
+        logger.debug(`cf_fingerprint(${modData.length} bytes): ${duration}ms`);
 
         // Use the CurseForge API to get file info by fingerprint
         const resp = await this.fetchClient(`${CurseForgeRepository.BASE_URL}/fingerprints`, {

--- a/mclib/src/repos/IRepository.ts
+++ b/mclib/src/repos/IRepository.ts
@@ -1,4 +1,4 @@
-import type { ModAndReleases, ModSearchMetadata, ModRepositoryName } from "..";
+import type { ModReleases, ModRepoMetadata, ModRepositoryName } from "..";
 
 /**
  * Interface for a mod repository
@@ -16,21 +16,21 @@ export interface IRepository {
      * @param modId The ID of the mod.
      * @returns A promise resolving to an array of mod releases.
      */
-    getModReleases(modId: string): Promise<ModAndReleases>;
+    getModReleases(modId: string): Promise<ModReleases>;
 
     /**
      * Search for mods by a query string.
      * @param query The search query.
      * @returns A promise resolving to an array of mods matching the query.
      */
-    searchMods(query: string, maxResults: number): Promise<ModSearchMetadata[]>;
+    searchMods(query: string, maxResults: number): Promise<ModRepoMetadata[]>;
 
     /**
      * Get mod information by file hash/fingerprint from mod file bytes.
      * @param modData The complete mod file data as bytes.
      * @returns A promise resolving to mod search metadata, or null if not found.
      */
-    getByDataHash(modData: Uint8Array): Promise<ModSearchMetadata | null>;
+    getByDataHash(modData: Uint8Array): Promise<ModRepoMetadata | null>;
 
     /**
      * Returns the repository name (ModRepositoryName enum value)

--- a/mclib/src/repos/ModrinthRepository.ts
+++ b/mclib/src/repos/ModrinthRepository.ts
@@ -58,12 +58,12 @@ export class ModrinthRepository implements IRepository {
         const hash = await this.calculateSHA1(modData);
         
         // Get version info using the hash
-        const versionResp = await fetch(`https://api.modrinth.com/v2/version_file/${hash}`);
+        const versionResp = await this.fetchClient(`https://api.modrinth.com/v2/version_file/${hash}`);
         if (!versionResp.ok) return null;
         const versionData = await versionResp.json();
         
         // Get project info using the project ID
-        const projectResp = await fetch(`https://api.modrinth.com/v2/project/${versionData.project_id}`);
+        const projectResp = await this.fetchClient(`https://api.modrinth.com/v2/project/${versionData.project_id}`);
         if (!projectResp.ok) return null;
         const projectData = await projectResp.json();
         

--- a/mclib/src/repos/ModrinthRepository.ts
+++ b/mclib/src/repos/ModrinthRepository.ts
@@ -18,10 +18,6 @@ export class ModrinthRepository implements IRepository {
     }
 
     async getModReleases(modId: string): Promise<ModAndReleases> {
-        const projectResp = await this.fetchClient(`https://api.modrinth.com/v2/project/${modId}`);
-        if (!projectResp.ok) throw new Error("Mod not found on Modrinth");
-        const projectData = await projectResp.json();
-
         const versionsResp = await this.fetchClient(`https://api.modrinth.com/v2/project/${modId}/version`);
         if (!versionsResp.ok) throw new Error("Could not fetch versions from Modrinth");
         const versionsData = await versionsResp.json();

--- a/mclib/src/repos/ModrinthRepository.ts
+++ b/mclib/src/repos/ModrinthRepository.ts
@@ -1,5 +1,5 @@
 import type { IRepository } from "./IRepository";
-import { ModAndReleases, ModRelease, ModRepositoryName, ModLoader, ModSearchMetadata } from "..";
+import { ModAndReleases, ModRelease, ModRepositoryName, ModSearchMetadata, ModLoaderUtil } from "..";
 
 export class ModrinthRepository implements IRepository {
 
@@ -26,7 +26,7 @@ export class ModrinthRepository implements IRepository {
             mcVersions: new Set(v.game_versions),
             modVersion: v.version_number,
             repository: ModRepositoryName.MODRINTH,
-            loaders: new Set(v.loaders.map((l: string) => ModLoader.from(l))),
+            loaders: new Set(v.loaders.map((l: string) => ModLoaderUtil.from(l))),
         }));
 
         return {

--- a/mclib/src/repos/ModrinthRepository.ts
+++ b/mclib/src/repos/ModrinthRepository.ts
@@ -27,10 +27,10 @@ export class ModrinthRepository implements IRepository {
         const versionsData = await versionsResp.json();
 
         const releases: ModRelease[] = versionsData.map((v: any) => ({
-            mcVersions: v.game_versions,
+            mcVersions: new Set(v.game_versions),
             modVersion: v.version_number,
             repository: ModRepositoryName.MODRINTH,
-            loaders: (v.loaders || []).map((l: string) => l as ModLoader),
+            loaders: new Set(v.loaders.map((l: string) => ModLoader.from(l))),
         }));
 
         return {

--- a/mclib/src/repos/ModrinthRepository.ts
+++ b/mclib/src/repos/ModrinthRepository.ts
@@ -34,7 +34,7 @@ export class ModrinthRepository implements IRepository {
         }));
 
         return {
-            name: projectData.title || projectData.slug || modId,
+            id: modId,
             releases,
         };
     }

--- a/mclib/src/repos/index.ts
+++ b/mclib/src/repos/index.ts
@@ -1,3 +1,24 @@
+import { logger } from "../logger";
+import { ModRepositoryName } from "../types";
+import { CurseForgeRepository } from "./CurseForgeRepository";
+import { IRepository } from "./IRepository";
+import { ModrinthRepository } from "./ModrinthRepository";
+
 export { ModrinthRepository } from "./ModrinthRepository";
 export { CurseForgeRepository } from "./CurseForgeRepository";
 export type { IRepository } from "./IRepository";
+
+export class RepositoryUtil {
+    static from(repo: ModRepositoryName, fetchClient: typeof fetch): IRepository | undefined {
+        switch (repo.toLowerCase()) {
+            case "modrinth":
+                return new ModrinthRepository(fetchClient);
+            case "curseforge":
+                return new CurseForgeRepository(fetchClient);
+            default: {
+                logger.error(`RepositoryUtil::from(%s): Unknown repository`, repo);
+                return undefined;
+            }
+        }
+    }
+}

--- a/mclib/src/types.ts
+++ b/mclib/src/types.ts
@@ -43,7 +43,7 @@ export type MCConfig = {
 };
 
 /** Represents a release of a mod */
-export type ModRelease = {
+export type ModRepoRelease = {
     /** List of Minecraft versions compatible with this release */
     mcVersions: Set<MCVersion>;
     /** Mod version */
@@ -52,36 +52,36 @@ export type ModRelease = {
     repository: ModRepositoryName;
     /** Compatible mod loaders */
     loaders: Set<ModLoader>;
+
+    modMetadata: ModRepoMetadata;
 };
 
-/** Represents metadata for a mod search result. */
-export type ModSearchMetadata = {
+export type ModMetadata = ModRepoMetadata[];
+
+export class ModMetadataUtil {
+    static toString(modMeta: ModMetadata): string {
+        return modMeta.map(m => `${m.repository}|${m.id}`).join(", ");
+    }
+}
+
+/** Represents metadata for a mod search result, for a given repository */
+export type ModRepoMetadata = {
     id: string;
+    repository: ModRepositoryName;
     name: string; // user-facing name
     homepageURL: string;
     imageURL: string;
     downloadCount: number;
 };
 
-export type ModAndRelease = {
-    id: string;
-    release: ModRelease;
-}
-
-/** Mod with all its available releases */
-export type ModAndReleases = {
-    /** Mod ID */
-    id: string;
-    /** Available releases of the mod */
-    releases: ModRelease[];
-};
+export type ModReleases = ModRepoRelease[]
 
 /** Solution to run the modpack, using the given Minecraft version/loader, and the mod releases to use */
 export type Solution = {
     /** The Minecraft configuration */
     mcConfig: MCConfig;
     /** The mod releases that are compatible with this configuration */
-    mods: ModAndRelease[];
+    mods: ModRepoRelease[];
 };
 
 /** Represents constraints for a modpack solution */

--- a/mclib/src/types.ts
+++ b/mclib/src/types.ts
@@ -1,5 +1,7 @@
 // simple types
 
+import { logger } from "./logger";
+
 export enum ModRepositoryName {
     MODRINTH = "modrinth",
     CURSEFORGE = "curseforge",
@@ -18,6 +20,19 @@ export enum ModLoader {
     NEOFORGE = "neoforge"
 }
 
+export namespace ModLoader {
+    export function from(loader: string): ModLoader {
+        loader = loader.toLowerCase();
+        for (const modLoader of Object.values(ModLoader)) {
+            if (modLoader === loader) {
+                return modLoader;
+            }
+        }
+        logger.trace(`Unknown mod loader: ${loader}`);
+        return loader as ModLoader;
+    }
+}
+
 /** Represents a Minecraft version */
 export type MCVersion = string;
 
@@ -30,13 +45,13 @@ export type MCConfig = {
 /** Represents a release of a mod */
 export type ModRelease = {
     /** List of Minecraft versions compatible with this release */
-    mcVersions: MCVersion[];
+    mcVersions: Set<MCVersion>;
     /** Mod version */
     modVersion: string;
     /** Repository where the release is available */
     repository: ModRepositoryName;
     /** Compatible mod loaders */
-    loaders: ModLoader[];
+    loaders: Set<ModLoader>;
 };
 
 /** Represents metadata for a mod search result. */
@@ -73,5 +88,5 @@ export type Solution = {
 export class Constraints {
     minVersion?: MCVersion;
     maxVersion?: MCVersion;
-    loaders?: ModLoader[];
+    loaders?: Set<ModLoader>;
 }

--- a/mclib/src/types.ts
+++ b/mclib/src/types.ts
@@ -20,12 +20,12 @@ export enum ModLoader {
     NEOFORGE = "neoforge"
 }
 
-export namespace ModLoader {
-    export function from(loader: string): ModLoader {
+export class ModLoaderUtil {
+    static from(loader: string): ModLoader {
         loader = loader.toLowerCase();
         for (const modLoader of Object.values(ModLoader)) {
             if (modLoader === loader) {
-                return modLoader;
+                return modLoader as ModLoader;
             }
         }
         logger.trace(`Unknown mod loader: ${loader}`);

--- a/mclib/src/types.ts
+++ b/mclib/src/types.ts
@@ -49,14 +49,14 @@ export type ModSearchMetadata = {
 };
 
 export type ModAndRelease = {
-    name: string;
+    id: string;
     release: ModRelease;
 }
 
 /** Mod with all its available releases */
 export type ModAndReleases = {
-    /** Mod name */
-    name: string;
+    /** Mod ID */
+    id: string;
     /** Available releases of the mod */
     releases: ModRelease[];
 };

--- a/web/src/components/FileDropZone.svelte
+++ b/web/src/components/FileDropZone.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import * as m from '$msg';
-	import type { ModSearchMetadata } from 'mclib';
+	import type { ModRepoMetadata } from 'mclib';
 	import { repositories } from '../config';
 
 	let {
 		add_mod_to_list
 	}: {
-		add_mod_to_list: (mod: ModSearchMetadata) => void;
+		add_mod_to_list: (mod: ModRepoMetadata) => void;
 	} = $props();
 
 	let isDragging = $state(false);

--- a/web/src/components/ModSearch.svelte
+++ b/web/src/components/ModSearch.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import * as m from '$msg';
 	import { ModRepositoryName } from 'mclib';
-	import type { ModSearchMetadata } from 'mclib';
+	import type { ModRepoMetadata } from 'mclib';
 	import { ModSearchList, ToggleButtons } from '$cmpts';
 	import { slide } from 'svelte/transition';
 	import { modQueryService, repositories } from '../config';
@@ -13,9 +13,9 @@
 		add_mod_to_list
 	}: {
 		search_name_input: string;
-		search_results: [ModRepositoryName, ModSearchMetadata][];
+		search_results: [ModRepositoryName, ModRepoMetadata][];
 		is_loading_search: boolean;
-		add_mod_to_list: (mod: ModSearchMetadata) => void;
+		add_mod_to_list: (mod: ModRepoMetadata) => void;
 	} = $props();
 
 	let selected_mod_repo_names: ModRepositoryName[] = $state([]);

--- a/web/src/components/ModSearchList.svelte
+++ b/web/src/components/ModSearchList.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import * as m from '$msg';
-	import type { ModRepositoryName, ModSearchMetadata } from 'mclib';
+	import type { ModRepositoryName, ModRepoMetadata } from 'mclib';
 
 	let {
 		search_results = $bindable(),
 		add_mod_to_list
 	}: {
-		search_results: [ModRepositoryName, ModSearchMetadata][]; // list of (repository, mod search metadata)
-		add_mod_to_list: (mod: ModSearchMetadata) => void;
+		search_results: [ModRepositoryName, ModRepoMetadata][]; // list of (repository, mod search metadata)
+		add_mod_to_list: (mod: ModRepoMetadata) => void;
 	} = $props();
 
 	function humanize_number(input: number): string {

--- a/web/src/components/ModsList.svelte
+++ b/web/src/components/ModsList.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
 	import * as m from '$msg';
-	import type { ModSearchMetadata } from 'mclib';
+	import type { ModRepoMetadata } from 'mclib';
 	import { slide } from 'svelte/transition';
 
 	let {
 		mod_list_added = $bindable(),
 		remove_mod_from_list
 	}: {
-		mod_list_added: ModSearchMetadata[];
-		remove_mod_from_list: (mod: ModSearchMetadata) => void;
+		mod_list_added: ModRepoMetadata[];
+		remove_mod_from_list: (mod: ModRepoMetadata) => void;
 	} = $props();
 </script>
 

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { slide } from 'svelte/transition';
-	import type { Solution, ModSearchMetadata, ModRepositoryName, MCVersion } from 'mclib';
+	import type { Solution, ModRepoMetadata, ModRepositoryName, MCVersion } from 'mclib';
 	import { ModLoader } from 'mclib';
 	import { ModSearch, ModsList, ToggleButtons, MCVersionSelection, FileDropZone } from '$cmpts';
 	import * as m from '$msg';
@@ -8,11 +8,11 @@
 
 	let search_name_input = $state('');
 	let is_loading_search = $state(false);
-	let search_results: [ModRepositoryName, ModSearchMetadata][] = $state([]);
+	let search_results: [ModRepositoryName, ModRepoMetadata][] = $state([]);
 
-	let mod_list_added: ModSearchMetadata[] = $state([]);
+	let mod_list_added: ModRepoMetadata[] = $state([]);
 
-	function add_mod_to_list(mod: ModSearchMetadata): void {
+	function add_mod_to_list(mod: ModRepoMetadata): void {
 		if (!mod_list_added.includes(mod)) {
 			// add mod to list of mods to use
 			mod_list_added.push(mod);
@@ -21,7 +21,7 @@
 		}
 	}
 
-	function remove_mod_from_list(mod: ModSearchMetadata): void {
+	function remove_mod_from_list(mod: ModRepoMetadata): void {
 		const index_mod = mod_list_added.indexOf(mod);
 		if (index_mod > -1) {
 			mod_list_added.splice(index_mod, 1);


### PR DESCRIPTION
Instead, the identification of the mod will be done based on it's "ModMetadata" and "ModReleases" objects.

The reason is that mods do not have one single unique ID, but one per repository